### PR TITLE
se borra parametro ckan.valid_url_schemes que se vuelve a asignar en develop.ini

### DIFF
--- a/develop.ini
+++ b/develop.ini
@@ -61,7 +61,6 @@ ckan.datastore.default_fts_index_method = gist
 ## Site Settings
 
 ckan.site_url = http://localhost
-ckan.valid_url_schemes = http https
 #ckan.use_pylons_response_cleanup_middleware = true
 
 ckan.valid_url_schemes = http https ftp sftp


### PR DESCRIPTION
no me di cuenta cuando acepté el PR #10 que 3 lineas antes estaba definido